### PR TITLE
Update numpy to 2.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.115.5 
 uvicorn==0.22.0
-numpy==1.23.0
+numpy==2.1.3


### PR DESCRIPTION
This PR updates numpy from 1.23.0 to 2.1.3.
                
                Tested with Python 3.11